### PR TITLE
Logs

### DIFF
--- a/node.go
+++ b/node.go
@@ -126,7 +126,8 @@ func (node *Node) SendOrderFragment(ctx context.Context, orderFragment *rpc.Orde
 	}
 }
 
-// Logs ...
+// Logs will create a logs channel with the delegate and send any received logs
+// through the RPC stream.
 func (node *Node) Logs(logRequest *rpc.LogRequest, stream rpc.DarkNode_LogsServer) error {
 	if node.Options.Debug >= DebugHigh {
 		log.Printf("[%v] received a log query", node.Address())

--- a/node.go
+++ b/node.go
@@ -329,7 +329,7 @@ func (node *Node) sync(syncRequest *rpc.SyncRequest, stream rpc.DarkNode_SyncSer
 }
 
 func (node *Node) logs(logsRequest *rpc.LogRequest, stream rpc.DarkNode_LogsServer) error {
-	logChannel := make(chan do.Option, 128)
+	logChannel := make(chan do.Option)
 	node.Delegate.SubscribeToLogs(logChannel)
 	defer node.Delegate.UnsubscribeFromLogs(logChannel)
 	for event := range logChannel {

--- a/node.go
+++ b/node.go
@@ -332,7 +332,10 @@ func (node *Node) sync(syncRequest *rpc.SyncRequest, stream rpc.DarkNode_SyncSer
 func (node *Node) logs(logsRequest *rpc.LogRequest, stream rpc.DarkNode_LogsServer) error {
 	logChannel := make(chan do.Option)
 	node.Delegate.SubscribeToLogs(logChannel)
-	defer node.Delegate.UnsubscribeFromLogs(logChannel)
+	defer func() {
+		node.Delegate.UnsubscribeFromLogs(logChannel)
+		close(logChannel)
+	}()
 	for event := range logChannel {
 		// TODO: need to serialize data into the network representation
 		if err := stream.Send(event.Ok.(*rpc.LogEvent)); err != nil {

--- a/node_test.go
+++ b/node_test.go
@@ -58,6 +58,12 @@ func (delegate *mockDelegate) OnSync(from identity.MultiAddress) chan do.Option 
 	return syncBlock
 }
 
+func (delegate *mockDelegate) OnLogs() chan do.Option {
+	logEvent := make(chan do.Option, 1)
+	logEvent <- do.Ok(&rpc.logEvent{})
+	return logEvent
+}
+
 func (delegate *mockDelegate) OnElectShard(from identity.MultiAddress, shard compute.Shard) compute.Shard {
 	return compute.Shard{}
 }

--- a/node_test.go
+++ b/node_test.go
@@ -46,7 +46,10 @@ func (delegate *mockDelegate) OnSync(from identity.MultiAddress) chan do.Option 
 	return syncBlock
 }
 
-func (delegate *mockDelegate) SubscribeToLogs(chan do.Option) {
+func (delegate *mockDelegate) SubscribeToLogs(channel chan do.Option) {
+	go func() {
+		channel <- do.Ok(&rpc.LogEvent{Type: []byte("type"), Message: []byte("message")})
+	}()
 }
 
 func (delegate *mockDelegate) UnsubscribeFromLogs(chan do.Option) {
@@ -292,75 +295,71 @@ var _ = Describe("dark network", func() {
 	//	})
 	//})
 
-	// Context("rpc call handlers", func() {
-	// 	var nodes []*dark.Node
-	// 	var listeners []net.Listener
-	// 	var delegate *mockDelegate
-	// 	var err error
-	// 	var numberOfNodes = 2
-	// 	var from, to identity.MultiAddress
+	Context("rpc call handlers", func() {
+		var nodes []*dark.Node
+		var listeners []net.Listener
+		var delegate *mockDelegate
+		var err error
+		var numberOfNodes = 2
+		var from, to identity.MultiAddress
 
-	// 	BeforeEach(func() {
-	// 		mu.Lock()
-	// 		delegate = newMockDelegate()
-	// 		nodes, err = createNodes(delegate, numberOfNodes)
-	// 		nodes[0].Options.Debug = dark.DebugHigh
-	// 		nodes[1].Options.Debug = dark.DebugHigh
-	// 		Ω(err).ShouldNot(HaveOccurred())
-	// 		listeners, err = createListener(numberOfNodes)
-	// 		Ω(err).ShouldNot(HaveOccurred())
-	// 		startListening(nodes, listeners)
-	// 		from, err = identity.NewMultiAddressFromString(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d/republic/%s", DefaultNodePort, nodes[0].Address()))
-	// 		Ω(err).ShouldNot(HaveOccurred())
-	// 		to, err = identity.NewMultiAddressFromString(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d/republic/%s", DefaultNodePort+1, nodes[1].Address()))
-	// 		Ω(err).ShouldNot(HaveOccurred())
-	// 	})
-	//
-	// 	AfterEach(func() {
-	// 		stopListening(nodes, listeners)
-	// 		mu.Unlock()
-	// 	})
-	//
-	// 	It("should be able to send logs to a log request", func() {
-	// 		logs, quit := rpc.Logs(to, DefaultTimeOut)
-	// 		fmt.Println("trying...")
-	// 		_ = <-logs
-	// 		fmt.Println("got!...")
-	// 		quit <- struct{}{}
-	// 		fmt.Println("quit, emptying...")
-	// 		for len(logs) > 0 {
-	// 			<-logs
-	// 		}
-	// 	})
-	// })
-	//
-	//	It("should be able to respond to sync query", func() {
-	//		option, quit := rpc.SyncWithTarget(to, from, DefaultTimeOut)
-	//		_ = <-option
-	//		quit <- struct{}{}
-	//	})
-	//
-	//	It("should be able to respond to send order fragment commitment query", func() {
-	//		err := rpc.SendOrderFragmentCommitmentToTarget(to, from, DefaultTimeOut)
-	//		Ω(err).ShouldNot(HaveOccurred())
-	//	})
-	//
-	//	It("should be able to respond to compute shard query", func() {
-	//		err := rpc.AskToComputeShard(to, from, compute.Shard{}, DefaultTimeOut)
-	//		Ω(err).ShouldNot(HaveOccurred())
-	//	})
-	//
-	//	It("should be able to respond to elect shard query", func() {
-	//		shard, err := rpc.StartElectShard(to, from, compute.Shard{}, DefaultTimeOut)
-	//		Ω(err).ShouldNot(HaveOccurred())
-	//		Ω(*shard).Should(Equal(rpc.Shard{}))
-	//	})
-	//
-	//	It("should be able to respond to finalize shard query", func() {
-	//		err := rpc.FinalizeShard(to, from, compute.DeltaShard{}, DefaultTimeOut)
-	//		Ω(err).ShouldNot(HaveOccurred())
-	//	})
-	//})
+		BeforeEach(func() {
+			mu.Lock()
+			delegate = newMockDelegate()
+			nodes, err = createNodes(delegate, numberOfNodes)
+			nodes[0].Options.Debug = dark.DebugHigh
+			nodes[1].Options.Debug = dark.DebugHigh
+			Ω(err).ShouldNot(HaveOccurred())
+			listeners, err = createListener(numberOfNodes)
+			Ω(err).ShouldNot(HaveOccurred())
+			startListening(nodes, listeners)
+			from, err = identity.NewMultiAddressFromString(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d/republic/%s", DefaultNodePort, nodes[0].Address()))
+			Ω(err).ShouldNot(HaveOccurred())
+			to, err = identity.NewMultiAddressFromString(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d/republic/%s", DefaultNodePort+1, nodes[1].Address()))
+			Ω(err).ShouldNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			stopListening(nodes, listeners)
+			mu.Unlock()
+		})
+
+		It("should be able to send logs to a log request", func() {
+			logs, quit := rpc.Logs(to, DefaultTimeOut)
+			_ = <-logs
+			quit <- struct{}{}
+			for len(logs) > 0 {
+				<-logs
+			}
+		})
+
+		//	It("should be able to respond to sync query", func() {
+		//		option, quit := rpc.SyncWithTarget(to, from, DefaultTimeOut)
+		//		_ = <-option
+		//		quit <- struct{}{}
+		//	})
+		//
+		//	It("should be able to respond to send order fragment commitment query", func() {
+		//		err := rpc.SendOrderFragmentCommitmentToTarget(to, from, DefaultTimeOut)
+		//		Ω(err).ShouldNot(HaveOccurred())
+		//	})
+		//
+		//	It("should be able to respond to compute shard query", func() {
+		//		err := rpc.AskToComputeShard(to, from, compute.Shard{}, DefaultTimeOut)
+		//		Ω(err).ShouldNot(HaveOccurred())
+		//	})
+		//
+		//	It("should be able to respond to elect shard query", func() {
+		//		shard, err := rpc.StartElectShard(to, from, compute.Shard{}, DefaultTimeOut)
+		//		Ω(err).ShouldNot(HaveOccurred())
+		//		Ω(*shard).Should(Equal(rpc.Shard{}))
+		//	})
+		//
+		//	It("should be able to respond to finalize shard query", func() {
+		//		err := rpc.FinalizeShard(to, from, compute.DeltaShard{}, DefaultTimeOut)
+		//		Ω(err).ShouldNot(HaveOccurred())
+		//	})
+	})
 })
 
 func randomOrderFragment() *compute.OrderFragment {

--- a/node_test.go
+++ b/node_test.go
@@ -292,34 +292,47 @@ var _ = Describe("dark network", func() {
 	//	})
 	//})
 
-	//Context("rpc call handlers", func() {
-	//	var nodes []*dark.Node
-	//	var listeners []net.Listener
-	//	var delegate *mockDelegate
-	//	var err error
-	//	var numberOfNodes = 2
-	//	var from, to identity.MultiAddress
+	// Context("rpc call handlers", func() {
+	// 	var nodes []*dark.Node
+	// 	var listeners []net.Listener
+	// 	var delegate *mockDelegate
+	// 	var err error
+	// 	var numberOfNodes = 2
+	// 	var from, to identity.MultiAddress
+
+	// 	BeforeEach(func() {
+	// 		mu.Lock()
+	// 		delegate = newMockDelegate()
+	// 		nodes, err = createNodes(delegate, numberOfNodes)
+	// 		nodes[0].Options.Debug = dark.DebugHigh
+	// 		nodes[1].Options.Debug = dark.DebugHigh
+	// 		Ω(err).ShouldNot(HaveOccurred())
+	// 		listeners, err = createListener(numberOfNodes)
+	// 		Ω(err).ShouldNot(HaveOccurred())
+	// 		startListening(nodes, listeners)
+	// 		from, err = identity.NewMultiAddressFromString(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d/republic/%s", DefaultNodePort, nodes[0].Address()))
+	// 		Ω(err).ShouldNot(HaveOccurred())
+	// 		to, err = identity.NewMultiAddressFromString(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d/republic/%s", DefaultNodePort+1, nodes[1].Address()))
+	// 		Ω(err).ShouldNot(HaveOccurred())
+	// 	})
 	//
-	//	BeforeEach(func() {
-	//		mu.Lock()
-	//		delegate = newMockDelegate()
-	//		nodes, err = createNodes(delegate, numberOfNodes)
-	//		nodes[0].Options.Debug = dark.DebugHigh
-	//		nodes[1].Options.Debug = dark.DebugHigh
-	//		Ω(err).ShouldNot(HaveOccurred())
-	//		listeners, err = createListener(numberOfNodes)
-	//		Ω(err).ShouldNot(HaveOccurred())
-	//		startListening(nodes, listeners)
-	//		from, err = identity.NewMultiAddressFromString(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d/republic/%s", DefaultNodePort, nodes[0].Address()))
-	//		Ω(err).ShouldNot(HaveOccurred())
-	//		to, err = identity.NewMultiAddressFromString(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d/republic/%s", DefaultNodePort+1, nodes[1].Address()))
-	//		Ω(err).ShouldNot(HaveOccurred())
-	//	})
+	// 	AfterEach(func() {
+	// 		stopListening(nodes, listeners)
+	// 		mu.Unlock()
+	// 	})
 	//
-	//	AfterEach(func() {
-	//		stopListening(nodes, listeners)
-	//		mu.Unlock()
-	//	})
+	// 	It("should be able to send logs to a log request", func() {
+	// 		logs, quit := rpc.Logs(to, DefaultTimeOut)
+	// 		fmt.Println("trying...")
+	// 		_ = <-logs
+	// 		fmt.Println("got!...")
+	// 		quit <- struct{}{}
+	// 		fmt.Println("quit, emptying...")
+	// 		for len(logs) > 0 {
+	// 			<-logs
+	// 		}
+	// 	})
+	// })
 	//
 	//	It("should be able to respond to sync query", func() {
 	//		option, quit := rpc.SyncWithTarget(to, from, DefaultTimeOut)

--- a/node_test.go
+++ b/node_test.go
@@ -60,7 +60,7 @@ func (delegate *mockDelegate) OnSync(from identity.MultiAddress) chan do.Option 
 
 func (delegate *mockDelegate) OnLogs() chan do.Option {
 	logEvent := make(chan do.Option, 1)
-	logEvent <- do.Ok(&rpc.logEvent{})
+	logEvent <- do.Ok(&rpc.LogEvent{})
 	return logEvent
 }
 


### PR DESCRIPTION
This PR adds two functions to the dark node delegate:

```go
SubscribeToLogs(chan do.Option)
UnsubscribeFromLogs(chan do.Option)
```

And the following function which calls the delegate:

```go
Logs(logRequest *rpc.LogRequest, stream rpc.DarkNode_LogsServer) error
```